### PR TITLE
🎨 Change asset path to /ghost/assets

### DIFF
--- a/addon/components/ghost-toolbar.js
+++ b/addon/components/ghost-toolbar.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
         let editor = this.editor = this.get('editor');
         this.tools = Tools(editor);
 
-        this.iconURL = ghostPaths().adminRoot + '/tools/';
+        this.iconURL = ghostPaths().assetRoot + 'tools/';
     },
     didRender() {
         let $this = this.$();

--- a/addon/utils/ghost-paths.js
+++ b/addon/utils/ghost-paths.js
@@ -18,6 +18,7 @@ export default function () {
     let path = window.location.pathname;
     let subdir = path.substr(0, path.search('/ghost/'));
     let adminRoot = `${subdir}/ghost/`;
+    let assetRoot = `${subdir}/ghost/assets/`;
     let apiRoot = `${subdir}/ghost/api/v0.1`;
 
     function assetUrl(src) {
@@ -26,6 +27,7 @@ export default function () {
 
     return {
         adminRoot,
+        assetRoot,
         apiRoot,
         subdir,
         blogRoot: `${subdir}/`,


### PR DESCRIPTION
I didn't quite figure out how to test this inside of Ghost, but the paths that are requested now look correct.

Not sure if the change to using `/assets/` in the URL here is helpful to make it possible to view the icons when testing locally?

refs TryGhost/Ghost#7503

- In Ghost & Ghost-Admin the path has already been changed to ghost/assets
- This adds the same change here
- Note: the icons don't work when using ember serve inside this repo before or after this commit